### PR TITLE
added clustered bootstrap and associated unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,6 +58,6 @@ URL: https://bdwilliamson.github.io/vimp/,
     https://github.com/bdwilliamson/vimp,
     http://bdwilliamson.github.io/vimp/
 BugReports: https://github.com/bdwilliamson/vimp/issues
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 LazyData: true

--- a/R/bootstrap_se.R
+++ b/R/bootstrap_se.R
@@ -1,12 +1,13 @@
 #' Compute bootstrap-based standard error estimates for variable importance
-#' 
+#'
 #' @inheritParams vim
-#' 
+#'
 #' @return a bootstrap-based standard error estimate
-#' 
+#'
 #' @importFrom boot boot boot.ci
 #' @export
-bootstrap_se <- function(Y = NULL, f1 = NULL, f2 = NULL, 
+bootstrap_se <- function(Y = NULL, f1 = NULL, f2 = NULL,
+                         cluster_id = NULL, clustered = FALSE,
                          type = "r_squared", b = 1000,
                          boot_interval_type = "perc", alpha = 0.05) {
   vim_boot_stat <- function(data, indices, type) {
@@ -22,12 +23,36 @@ bootstrap_se <- function(Y = NULL, f1 = NULL, f2 = NULL,
     est_vim <- predictiveness_full - predictiveness_reduced
     c(vim = est_vim, pred_full = predictiveness_full, pred_redu = predictiveness_reduced)
   }
-  bootstrapped_ests <- boot::boot(data = data.frame(y = as.numeric(Y), f1 = f1, f2 = f2),
-                                  statistic = vim_boot_stat, R = b, 
-                                  sim = "ordinary", stype = "i", 
-                                  type = type)
+
+  if (!clustered){
+    bootstrapped_ests <- boot::boot(data = data.frame(y = as.numeric(Y), f1 = f1, f2 = f2),
+                                    statistic = vim_boot_stat, R = b,
+                                    sim = "ordinary", stype = "i",
+                                    type = type)
+  } else{
+    single_boot_rep <- function(data){
+      n_clust <- length(unique(data$cluster_id))
+      sampled_clusts <- sample(unique(data$cluster_id),
+                               size = n_clust,
+                               replace = TRUE)
+      sampled_rows <- which(data$cluster_id %in% sampled_clusts)
+      return(vim_boot_stat(data = data,
+                           indices = sampled_rows,
+                           type = type))
+    }
+    .dat <- data.frame(y = as.numeric(Y),
+                      f1 = f1,
+                      f2 = f2,
+                      cluster_id = cluster_id)
+    b_boot_ests <- t(replicate(b, single_boot_rep(data = .dat)))
+    overall_est <- vim_boot_stat(data = .dat, indices = 1:nrow(.dat), type = type)
+    # mimic the structure of "boot" object so that the boot.ci
+    # function can be used for CIs
+    bootstrapped_ests <- list(t0 = overall_est, t = b_boot_ests, R = b)
+  }
+
   vars <- apply(bootstrapped_ests$t, 2, function(x) mean( (x - mean( x ) ) ^ 2) )
-  ci_init <- boot::boot.ci(bootstrapped_ests, type = boot_interval_type, 
+  ci_init <- boot::boot.ci(bootstrapped_ests, type = boot_interval_type,
                            conf = 1 - alpha)[[4]]
   num_ci_cols <- length(ci_init)
   ci <- ci_init[, c(num_ci_cols - 1, num_ci_cols)]

--- a/R/cv_vim.R
+++ b/R/cv_vim.R
@@ -116,6 +116,7 @@
 #'  \item{cross_fitting_folds}{the folds used for cross-fitting}
 #'  \item{y}{the outcome}
 #'  \item{ipc_weights}{the weights}
+#'  \item{cluster_id}{the cluster IDs}
 #'  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 #' }
 #'
@@ -197,10 +198,16 @@ cv_vim <- function(Y = NULL, X = NULL, cross_fitted_f1 = NULL,
                    nuisance_estimators_full = NULL,
                    nuisance_estimators_reduced = NULL, exposure_name = NULL,
                    cross_fitted_se = TRUE, bootstrap = FALSE, b = 1000,
-                   boot_interval_type = "perc", ...) {
+                   boot_interval_type = "perc", clustered = FALSE,
+                   cluster_id = rep(NA, length(Y)), ...) {
     # check to see if f1 and f2 are missing
     # if the data is missing, stop and throw an error
     check_inputs(Y, X, cross_fitted_f1, cross_fitted_f2, indx)
+
+    if (bootstrap & clustered & sum(is.na(cluster_id)) > 0){
+      stop(paste0("If using clustered bootstrap, cluster IDs must be provided",
+                  " for all observations."))
+    }
 
     if (sample_splitting) {
         ss_V <- V * 2
@@ -399,7 +406,9 @@ cv_vim <- function(Y = NULL, X = NULL, cross_fitted_f1 = NULL,
         se_redu <- NA
         if (bootstrap) {
             boot_results <- bootstrap_se(Y = Y_cc, f1 = non_cf_full_preds,
-                                         f2 = non_cf_redu_preds, type = full_type, b = b)
+                                         f2 = non_cf_redu_preds, type = full_type,
+                                         b = b, clustered = clustered,
+                                         cluster_id = cluster_id)
             se <- boot_results$se
         }
     } else {
@@ -500,7 +509,8 @@ cv_vim <- function(Y = NULL, X = NULL, cross_fitted_f1 = NULL,
             boot_results <- bootstrap_se(Y = Y_cc, f1 = non_cf_full_preds,
                                          f2 = non_cf_redu_preds, type = full_type,
                                          b = b, boot_interval_type = boot_interval_type,
-                                         alpha = alpha)
+                                         alpha = alpha, clustered = clustered,
+                                         cluster_id = cluster_id)
             se <- boot_results$se
             se_full <- boot_results$se_full
             se_redu <- boot_results$se_reduced
@@ -682,6 +692,7 @@ cv_vim <- function(Y = NULL, X = NULL, cross_fitted_f1 = NULL,
                    ipc_weights = ipc_weights,
                    ipc_scale = ipc_scale,
                    scale = scale,
+                   cluster_id = cluster_id,
                    mat = mat)
 
     # make it also a vim and vim_type object

--- a/man/bootstrap_se.Rd
+++ b/man/bootstrap_se.Rd
@@ -8,6 +8,8 @@ bootstrap_se(
   Y = NULL,
   f1 = NULL,
   f2 = NULL,
+  cluster_id = NULL,
+  clustered = FALSE,
   type = "r_squared",
   b = 1000,
   boot_interval_type = "perc",
@@ -27,6 +29,12 @@ regressing either (a) \code{f1} or (b) Y on X withholding the columns in
 \code{indx}. A vector of the same length as \code{Y}; if sample-splitting
 is desired, then the value of \code{f2} at each position should be the result
 of predicting from a model trained without that observation.}
+
+\item{cluster_id}{vector of the same length as \code{Y} giving the cluster IDs
+used for the clustered bootstrap, if \code{clustered} is \code{TRUE}.}
+
+\item{clustered}{should the bootstrap resamples be performed on clusters
+rather than individual observations? Defaults to \code{FALSE}.}
 
 \item{type}{the type of importance to compute; defaults to
 \code{r_squared}, but other supported options are \code{auc},

--- a/man/cv_vim.Rd
+++ b/man/cv_vim.Rd
@@ -38,6 +38,8 @@ cv_vim(
   bootstrap = FALSE,
   b = 1000,
   boot_interval_type = "perc",
+  clustered = FALSE,
+  cluster_id = rep(NA, length(Y)),
   ...
 )
 }
@@ -195,6 +197,12 @@ and \code{sample_splitting = FALSE}); defaults to 1000.}
 \code{"basic"}, \code{"stud"}, \code{"perc"}, or \code{"bca"}, as in
 \code{\link{boot}{boot.ci}}) if requested. Defaults to \code{"perc"}.}
 
+\item{clustered}{should the bootstrap resamples be performed on clusters
+rather than individual observations? Defaults to \code{FALSE}.}
+
+\item{cluster_id}{vector of the same length as \code{Y} giving the cluster IDs
+used for the clustered bootstrap, if \code{clustered} is \code{TRUE}.}
+
 \item{...}{other arguments to the estimation tool, see "See also".}
 }
 \value{
@@ -277,6 +285,7 @@ within the \code{vim} object. This results in a list including:
  \item{cross_fitting_folds}{the folds used for cross-fitting}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/man/vim.Rd
+++ b/man/vim.Rd
@@ -33,6 +33,8 @@ vim(
   bootstrap = FALSE,
   b = 1000,
   boot_interval_type = "perc",
+  clustered = FALSE,
+  cluster_id = rep(NA, length(Y)),
   ...
 )
 }
@@ -157,6 +159,12 @@ and \code{sample_splitting = FALSE}); defaults to 1000.}
 \code{"basic"}, \code{"stud"}, \code{"perc"}, or \code{"bca"}, as in
 \code{\link{boot}{boot.ci}}) if requested. Defaults to \code{"perc"}.}
 
+\item{clustered}{should the bootstrap resamples be performed on clusters
+rather than individual observations? Defaults to \code{FALSE}.}
+
+\item{cluster_id}{vector of the same length as \code{Y} giving the cluster IDs
+used for the clustered bootstrap, if \code{clustered} is \code{TRUE}.}
+
 \item{...}{other arguments to the estimation tool, see "See also".}
 }
 \value{
@@ -204,6 +212,7 @@ within the \code{vim} object. This results in a list including:
  \item{sample_splitting_folds}{the folds used for sample-splitting (used for hypothesis testing)}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/man/vimp_accuracy.Rd
+++ b/man/vimp_accuracy.Rd
@@ -227,6 +227,7 @@ within the \code{vim} object. This results in a list including:
  \item{cross_fitting_folds}{the folds used for cross-fitting}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/man/vimp_auc.Rd
+++ b/man/vimp_auc.Rd
@@ -227,6 +227,7 @@ within the \code{vim} object. This results in a list including:
  \item{cross_fitting_folds}{the folds used for cross-fitting}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/man/vimp_deviance.Rd
+++ b/man/vimp_deviance.Rd
@@ -227,6 +227,7 @@ within the \code{vim} object. This results in a list including:
  \item{cross_fitting_folds}{the folds used for cross-fitting}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/man/vimp_rsquared.Rd
+++ b/man/vimp_rsquared.Rd
@@ -227,6 +227,7 @@ within the \code{vim} object. This results in a list including:
  \item{cross_fitting_folds}{the folds used for cross-fitting}
  \item{y}{the outcome}
  \item{ipc_weights}{the weights}
+ \item{cluster_id}{the cluster IDs}
  \item{mat}{a tibble with the estimate, SE, CI, hypothesis testing decision, and p-value}
 }
 }

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -10,7 +10,7 @@ x <- as.data.frame(replicate(p, stats::rnorm(n, 0, 1)))
 # apply the function to the covariates
 y <- 1 + 0.5 * x[, 1] + 0.75 * x[, 2] + stats::rnorm(n, 0, 1)
 true_var <- 1 + .5 ^ 2 + .75 ^ 2
-# note that true difference in R-squareds for variable j, under independence, is 
+# note that true difference in R-squareds for variable j, under independence, is
 # beta_j^2 * var(x_j) / var(y)
 r2_one <- 0.5 ^ 2 * 1 / true_var
 r2_two <- 0.75 ^ 2 * 1 / true_var
@@ -24,10 +24,25 @@ set.seed(1234)
 test_that("Bootstrap without cross-fitting works", {
   # a small number of bootstraps, for speed
   expect_warning(
-    est <- vim(Y = y, X = x, run_regression = TRUE, SL.library = learners, 
+    est <- vim(Y = y, X = x, run_regression = TRUE, SL.library = learners,
                cvControl = list(V = V), indx = 1, type = "r_squared",
-               sample_splitting = FALSE, env = environment(), 
+               sample_splitting = FALSE, env = environment(),
                bootstrap = TRUE, b = 10, boot_interval_type = "perc")
+  )
+  expect_true(est$ci[1] <= r2_one & est$ci[2] >= r2_one)
+})
+
+cluster_id <- 1:length(y)
+set.seed(0714)
+test_that("Clustered bootstrap without cross-fitting produces similar results
+          to unclustered.", {
+  # a small number of bootstraps, for speed
+  expect_warning(
+    est <- vim(Y = y, X = x, run_regression = TRUE, SL.library = learners,
+               cvControl = list(V = V), indx = 1, type = "r_squared",
+               sample_splitting = FALSE, env = environment(),
+               bootstrap = TRUE, b = 10, boot_interval_type = "perc",
+               clustered = TRUE, cluster_id = cluster_id)
   )
   expect_true(est$ci[1] <= r2_one & est$ci[2] >= r2_one)
 })
@@ -35,11 +50,26 @@ set.seed(4747)
 test_that("Bootstrap with cross-fitting works", {
   # small number of boostraps, for speed
   expect_warning(
-    est <- cv_vim(Y = y, X = x, run_regression = TRUE, SL.library = learners, 
+    est <- cv_vim(Y = y, X = x, run_regression = TRUE, SL.library = learners,
                   cvControl = list(V = V), indx = 1, V = V, type = "r_squared",
-                  sample_splitting = FALSE, env = environment(), 
+                  sample_splitting = FALSE, env = environment(),
                   bootstrap = TRUE, b = 10, cross_fitted_se = FALSE,
-                  boot_interval_type = "perc")  
+                  boot_interval_type = "perc")
+  )
+  # check that the estimate is nearly correct
+  expect_true(est$ci[1] <= r2_one & est$ci[2] >= r2_one)
+})
+set.seed(5949)
+test_that("Clustered bootstrap with cross-fitting produces similar
+          estimates to unclustered", {
+  # small number of boostraps, for speed
+  expect_warning(
+    est <- cv_vim(Y = y, X = x, run_regression = TRUE, SL.library = learners,
+                  cvControl = list(V = V), indx = 1, V = V, type = "r_squared",
+                  sample_splitting = FALSE, env = environment(),
+                  bootstrap = TRUE, b = 10, cross_fitted_se = FALSE,
+                  boot_interval_type = "perc", clustered = TRUE,
+                  cluster_id = cluster_id)
   )
   # check that the estimate is nearly correct
   expect_true(est$ci[1] <= r2_one & est$ci[2] >= r2_one)


### PR DESCRIPTION
As a stopgap measure for clustered data, implemented a cluster-level bootstrap within `bootstrap_se()`. Added documentation to `vim()` and `cv_vim()`, as well as some unit tests to confirm that with clusters of size one, results are similar to non-clustered (won't be identical because we're not using the built-in `boot` machinery). 